### PR TITLE
Update scripts to handle string and boolean for powersaver

### DIFF
--- a/src/js/script.js
+++ b/src/js/script.js
@@ -245,6 +245,7 @@ const ConfigModule = {
       const apn = document.getElementById('apn');
       const simPin = document.getElementById('simPin');
       const powerSaver = document.getElementById('powerSaver');
+      const powerSaverStatus = document.getElementById('powerSaverStatus');
       const stagingUrl = document.getElementById('stagingUrl');
       const productionUrl = document.getElementById('productionUrl');
       const goLiveToggle = document.getElementById('goLiveToggle');
@@ -256,9 +257,12 @@ const ConfigModule = {
       if (simPin) simPin.value = config.simPin ?? '';
 
       if (powerSaver) {
-        powerSaver.checked = !!config.powerSaver;
-        document.getElementById('powerSaverStatus').textContent =
-          config.powerSaver ? 'On' : 'Off';
+        // when config.powerSaver is string "on" or boolean true, treat as enabled
+        powerSaver.checked =
+          config.powerSaver === 'on' || config.powerSaver === true;
+        if (powerSaverStatus) {
+          powerSaverStatus.textContent = powerSaver.checked ? 'On' : 'Off';
+        }
       }
 
       if (stagingUrl) {


### PR DESCRIPTION
This update improves the `ConfigModule` to correctly handle the `powerSaver` configuration state. Previously, the UI logic assumed a strictly boolean value, which caused issues when the web server returned the status as a string ("on" or "off"). 

The changes ensure the `powerSaver` checkbox and the associated status text accurately reflect the device state by normalizing inputs to handle both boolean `true` and the string `"on"`.

**Summary of Changes:**
* Updated `src/js/script.js` to evaluate `config.powerSaver` against both `true` and `"on"`.
* Ensured the `powerSaverStatus` text content is updated dynamically based on the normalized checkbox state.
* Added necessary DOM element selection for `powerSaverStatus` to prevent potential null reference errors during UI updates.