### PR TITLE
feat(config): add Home Assistant UI configuration options

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,6 +1,6 @@
 {
   "delay": 500,
-  "exec": "npm run build:debug",
+  "exec": "npm run serve",
   "ext": "html,css,js,png,jpg,svg",
   "legacyWatch": false,
   "watch": [

--- a/package.json
+++ b/package.json
@@ -35,12 +35,12 @@
     "build": "node build.js",
     "build:debug": "npm run clean && LOG_LEVEL=debug npm run build",
     "clean:svgs": "svgcleaner src dist || echo 'svgcleaner not found'",
-    "dev": "npm run watch",
+    "dev": "nodemon",
     "clean": "rm -rf dist",
     "optimize:svgs": "npx svgo -f src/icons -o dist/icons",
     "start": "node server/index.js",
     "test": "jest",
-    "watch": "nodemon"
+    "serve": "npm run build:debug && node server/index.js"
   },
   "type": "module",
   "version": "1.0.0"

--- a/server/index.js
+++ b/server/index.js
@@ -31,6 +31,16 @@ const DEFAULT_CONFIG = {
   stagingUrl: 'https://demo-sensor-data-staging-api.vercel.app/v1/push-sensor-data',
   productionUrl: 'https://demo-sensor-data-production-api.vercel.app/v1/push-sensor-data',
   isLive: false,
+  // Home Assistant MQTT configuration
+  haEnable: false,
+  haMqttBroker: '',
+  haMqttPort: 1883,
+  haMqttUsername: '',
+  haMqttPassword: '',
+  haDiscoveryPrefix: 'homeassistant',
+  haDeviceName: '',
+  haDeviceManufacturer: '',
+  haDeviceModel: '',
 };
 
 const DEMO_FILE_TREE = {
@@ -256,7 +266,7 @@ app.post('/ota_upload', upload.single('firmware'), (req, res) => {
   res.json({ status: 'success', message: 'Firmware uploaded (demo)' });
 });
 
-
+console.log("env: ", process.env.NODE_ENV);
 
 // Start the server only if not in production mode
 if (process.env.NODE_ENV !== 'production') {

--- a/src/config.html
+++ b/src/config.html
@@ -81,6 +81,18 @@
           >
             4
           </button>
+
+          <button
+            type="button"
+            class="stepper__indicator"
+            data-step="4"
+            role="tab"
+            aria-selected="false"
+            aria-controls="step-4"
+            id="step-ind-4"
+          >
+            5
+          </button>
         </div>
 
         <!-- Step 1: WiFi -->
@@ -252,6 +264,87 @@
                 Previous
               </button>
 
+              <button type="button" class="btn btn--primary next-btn" data-next="4">
+                Next
+              </button>
+            </div>
+          </fieldset>
+        </form>
+
+        <!-- Step 5: Home Assistant MQTT Configuration -->
+        <form
+          id="haForm"
+          class="config-form step hidden"
+          data-step="4"
+          aria-hidden="true"
+        >
+          <fieldset>
+            <legend class="sensor-group__title">Home Assistant Settings</legend>
+
+            <div class="form-group power-switch">
+              <label class="toggle-switch">
+                <input type="checkbox" id="haEnable" name="haEnable" />
+                <span class="toggle-track"></span>
+                <span class="toggle-label">Enable Home Assistant Integration:</span>
+                <span id="haEnableStatus" class="status-text">Disabled</span>
+              </label>
+            </div>
+
+            <div class="form-group">
+              <label for="haMqttBroker">MQTT Broker Host</label>
+                <input type="text" id="haMqttBroker" name="haMqttBroker" placeholder="192.168.1.50 or homeassistant.local" />
+            </div>
+
+            <div class="form-group">
+              <label for="haMqttPort">MQTT Port</label>
+              <input type="number" id="haMqttPort" name="haMqttPort" placeholder="1883" />
+            </div>
+
+            <div class="form-group">
+              <label for="haMqttUsername">MQTT Username</label>
+              <input type="text" id="haMqttUsername" name="haMqttUsername" />
+            </div>
+
+            <div class="form-group">
+              <label for="haMqttPassword">MQTT Password</label>
+              <div class="password-wrapper">
+                <input type="password" id="haMqttPassword" name="haMqttPassword" />
+                <label class="show-password-label" for="toggle-haMqttPassword">
+                  <input
+                    type="checkbox"
+                    id="toggle-haMqttPassword"
+                    aria-label="Show MQTT password"
+                    title="Show password"
+                    class="toggle-password"
+                  />
+                </label>
+              </div>
+            </div>
+
+            <div class="form-group">
+              <label for="haDiscoveryPrefix">Discovery Prefix</label>
+              <input type="text" id="haDiscoveryPrefix" name="haDiscoveryPrefix" placeholder="homeassistant" />
+            </div>
+
+            <div class="form-group">
+              <label for="haDeviceName">Device Name</label>
+              <input type="text" id="haDeviceName" name="haDeviceName" />
+            </div>
+
+            <div class="form-group">
+              <label for="haDeviceManufacturer">Device Manufacturer</label>
+              <input type="text" id="haDeviceManufacturer" name="haDeviceManufacturer" />
+            </div>
+
+            <div class="form-group">
+              <label for="haDeviceModel">Device Model</label>
+              <input type="text" id="haDeviceModel" name="haDeviceModel" />
+            </div>
+
+            <div class="step-btns">
+              <button type="button" class="btn prev-btn" data-prev="3">
+                Previous
+              </button>
               <button id="submit" type="submit" class="btn btn--primary">
                 Save Config
               </button>

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -250,6 +250,17 @@ const ConfigModule = {
       const goLiveToggle = document.getElementById('goLiveToggle');
       const goLiveStatus = document.getElementById('goLiveStatus');
 
+      const haEnable = document.getElementById('haEnable');
+      const haMqttBroker = document.getElementById('haMqttBroker');
+      const haMqttPort = document.getElementById('haMqttPort');
+      const haMqttUsername = document.getElementById('haMqttUsername');
+      const haMqttPassword = document.getElementById('haMqttPassword');
+      const haDiscoveryPrefix = document.getElementById('haDiscoveryPrefix');
+      const haDeviceName = document.getElementById('haDeviceName');
+      const haDeviceManufacturer = document.getElementById('haDeviceManufacturer');
+      const haDeviceModel = document.getElementById('haDeviceModel');
+      const haEnableStatus = document.getElementById('haEnableStatus');
+
       if (ssid) ssid.value = config.ssid ?? '';
       if (wifiPwd) wifiPwd.value = config.wifiPwd ?? '';
       if (apn) apn.value = config.apn ?? '';
@@ -282,10 +293,22 @@ const ConfigModule = {
           : 'Staging';
       }
 
+      if (haEnable) {
+        haEnable.checked = !!config.haEnable;
+        if (haEnableStatus) haEnableStatus.textContent = config.haEnable ? 'Enabled' : 'Disabled';
+      }
+      if (haMqttBroker) haMqttBroker.value = config.haMqttBroker ?? '';
+      if (haMqttPort) haMqttPort.value = config.haMqttPort ?? 1883;
+      if (haMqttUsername) haMqttUsername.value = config.haMqttUsername ?? '';
+      if (haMqttPassword) haMqttPassword.value = config.haMqttPassword ?? '';
+      if (haDiscoveryPrefix) haDiscoveryPrefix.value = config.haDiscoveryPrefix ?? 'homeassistant';
+      if (haDeviceName) haDeviceName.value = config.haDeviceName ?? '';
+      if (haDeviceManufacturer) haDeviceManufacturer.value = config.haDeviceManufacturer ?? '';
+      if (haDeviceModel) haDeviceModel.value = config.haDeviceModel ?? '';
+
       goLiveToggle.addEventListener('change', () => {
         const isLive = goLiveToggle.checked;
 
-        // 🔥 FIX: update disabled states dynamically
         stagingUrl.disabled = isLive;
         productionUrl.disabled = !isLive;
 
@@ -412,6 +435,15 @@ const ConfigModule = {
       updateGoLiveLabel();
     }
 
+    const haEnableInput = document.getElementById('haEnable');
+    const haEnableStatus = document.getElementById('haEnableStatus');
+    if (haEnableInput && haEnableStatus) {
+      const updateHaStatus = () => {
+        haEnableStatus.textContent = haEnableInput.checked ? 'Enabled' : 'Disabled';
+      };
+      haEnableInput.addEventListener('change', updateHaStatus);
+    }
+
     // final submit (collect all config-form fields)
     const saveHandler = async (e) => {
       e.preventDefault();
@@ -455,6 +487,9 @@ const ConfigModule = {
 
         allData.stagingUrl = (allData.stagingUrl || '').trim();
       }
+
+      allData.haEnable = !!allData.haEnable;
+      allData.haMqttPort = parseInt(allData.haMqttPort, 10) || 1883;
 
       console.log('Saving config', allData);
 


### PR DESCRIPTION
Adds a dedicated Home Assistant configuration step to the web interface, allowing users to override firmware default settings (HA_ENABLE, HA_MQTT_BROKER, HA_MQTT_PORT, credentials, discovery prefix, and device information) through the browser.

Closes #35 

Changes Introduced
 * index.js: Extended DEFAULT_CONFIG with default values for Home Assistant configuration properties (haEnable, haMqttBroker, haMqttPort, haMqttUsername, haMqttPassword, haDiscoveryPrefix, haDeviceName, haDeviceManufacturer, haDeviceModel).
 * config.html: Added a 5th step to the configuration wizard (#haForm) along with corresponding stepper indicators and navigation buttons.
 * script.js:
   * Updated ConfigModule.loadConfig() to populate HA input fields from /device-config.json.
   * Added dynamic toggle state tracking for haEnable.
   * Updated saveHandler to serialize HA inputs and convert haMqttPort to an integer before posting to /save-config.
How to Test
 * Run the demo server (npm run dev or node index.js).
 * Navigate to http://localhost:3030/config.html.
 * Step through the wizard to Step 5 (Home Assistant Settings).
 * Toggle Home Assistant enable state, input MQTT credentials and device metadata, then click Save Config.
 * Verify /tmp/device-config.json contains the updated HA properties.
